### PR TITLE
Allow for custom tags to be added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.13.1</version>
+    <version>1.14-SNAPSHOT</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>1.13.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.14-SNAPSHOT</version>
+    <version>1.13.2</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>1.13.2</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.14-SNAPSHOT</version>
+    <version>1.14</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>1.14</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.13.2</version>
+    <version>1.14-SNAPSHOT</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>1.13.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.14</version>
+    <version>1.15-SNAPSHOT</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>1.14</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
     <artifactId>influxdb</artifactId>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/InfluxDB+Plugin</url>
-    <version>1.14-SNAPSHOT</version>
+    <version>1.13.1</version>
     <packaging>hpi</packaging>
  
     <name>InfluxDB Plugin</name>
@@ -43,7 +43,7 @@ THE SOFTWARE.
         <connection>scm:git:ssh://github.com/jenkinsci/influxdb-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/influxdb-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/influxdb-plugin</url>
-        <tag>HEAD</tag>
+        <tag>1.13.1</tag>
     </scm>
 
     <properties>

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -94,6 +94,8 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      */
     private Map<String, Map<String, Object>> customDataMap;
 
+    private Map<String, String> globalTags;
+
     public InfluxDbPublisher() {
     }
 
@@ -154,6 +156,13 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     public Map<String, Map<String, Object>> getCustomDataMap() {
         return customDataMap;
     }
+
+    @DataBoundSetter
+    public void setGlobalTags(Map<String, String> globalTags) {
+        this.globalTags = globalTags;
+    }
+
+    public Map<String, String> getGlobalTags() { return globalTags; }
 
     public Target getTarget() {
         Target[] targets = DESCRIPTOR.getTargets();
@@ -223,7 +232,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             addPoints(pointsToWrite, cdGen, listener);
         }
 
-        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, customDataMap);
+        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, customDataMap, globalTags);
         if (cdmGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdmGen, listener);

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -158,11 +158,11 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     }
 
     @DataBoundSetter
-    public void setcustomDataMapTags(Map<String, String> customDataMapTags) {
+    public void setCustomDataMapTags(Map<String, String> customDataMapTags) {
         this.customDataMapTags = customDataMapTags;
     }
 
-    public Map<String, String> getcustomDataMapTags() { return customDataMapTags; }
+    public Map<String, String> getCustomDataMapTags() { return customDataMapTags; }
 
     public Target getTarget() {
         Target[] targets = DESCRIPTOR.getTargets();

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -94,7 +94,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      */
     private Map<String, Map<String, Object>> customDataMap;
 
-    private Map<String, String> globalTags;
+    private Map<String, String> customDataMapTags;
 
     public InfluxDbPublisher() {
     }
@@ -158,11 +158,11 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
     }
 
     @DataBoundSetter
-    public void setGlobalTags(Map<String, String> globalTags) {
-        this.globalTags = globalTags;
+    public void setcustomDataMapTags(Map<String, String> customDataMapTags) {
+        this.customDataMapTags = customDataMapTags;
     }
 
-    public Map<String, String> getGlobalTags() { return globalTags; }
+    public Map<String, String> getcustomDataMapTags() { return customDataMapTags; }
 
     public Target getTarget() {
         Target[] targets = DESCRIPTOR.getTargets();
@@ -232,7 +232,7 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
             addPoints(pointsToWrite, cdGen, listener);
         }
 
-        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, customDataMap, globalTags);
+        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, customPrefix, build, customDataMap, customDataMapTags);
         if (cdmGen.hasReport()) {
             listener.getLogger().println("[InfluxDB Plugin] Custom data map found. Writing to InfluxDB...");
             addPoints(pointsToWrite, cdmGen, listener);

--- a/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/InfluxDbPublisher.java
@@ -94,6 +94,21 @@ public class InfluxDbPublisher extends Notifier implements SimpleBuildStep{
      */
     private Map<String, Map<String, Object>> customDataMap;
 
+    /**
+     * custom tags that are sent to all measurements defined in customDataMaps.
+     *
+     * Example for a pipeline script:
+     *
+     * def myCustomTags = [:]
+     * myCustomTags["buildResult"] = currentBuild.result
+     * myCustomTags["NODE_LABELS"] = env.NODE_LABELS
+     * step([$class: 'InfluxDbPublisher',
+     *       target: myTarget,
+     *       customPrefix: 'myPrefix',
+     *       customDataMap: myCustomDataMap,
+     *       customDataMapTags: myCustomTags])
+     */
+
     private Map<String, String> customDataMapTags;
 
     public InfluxDbPublisher() {

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -12,13 +12,17 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
 
     private final Run<?, ?> build;
     private final String customPrefix;
-    Map<String, Map<String, Object>> customDataMap;
+    private final Map<String, Map<String, Object>> customDataMap;
+    private final Map<String, String> globalTags;
 
-    public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix, Run<?, ?> build, Map customDataMap) {
+    public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,
+                                       Run<?, ?> build, Map<String, Map<String, Object>> customDataMap,
+                                       Map<String, String> globalTags) {
         super(projectNameRenderer);
         this.build = build;
         this.customPrefix = customPrefix;
         this.customDataMap = customDataMap;
+        this.globalTags = globalTags;
     }
 
     public boolean hasReport() {
@@ -31,6 +35,7 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
         for (String key : customKeys) {
             Point point = buildPoint(measurementName(key), customPrefix, build)
                     .fields(customDataMap.get(key))
+                    .tag(globalTags)
                     .build();
             customPoints.add(point);
         }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -12,7 +12,7 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
 
     private final Run<?, ?> build;
     private final String customPrefix;
-    private final Map<String, Map<String, Object>> customDataMap;
+    Map<String, Map<String, Object>> customDataMap;
     private final Map<String, String> customDataMapTags;
 
     public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGenerator.java
@@ -13,16 +13,16 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
     private final Run<?, ?> build;
     private final String customPrefix;
     private final Map<String, Map<String, Object>> customDataMap;
-    private final Map<String, String> globalTags;
+    private final Map<String, String> customDataMapTags;
 
     public CustomDataMapPointGenerator(MeasurementRenderer<Run<?,?>> projectNameRenderer, String customPrefix,
                                        Run<?, ?> build, Map<String, Map<String, Object>> customDataMap,
-                                       Map<String, String> globalTags) {
+                                       Map<String, String> customDataMapTags) {
         super(projectNameRenderer);
         this.build = build;
         this.customPrefix = customPrefix;
         this.customDataMap = customDataMap;
-        this.globalTags = globalTags;
+        this.customDataMapTags = customDataMapTags;
     }
 
     public boolean hasReport() {
@@ -35,7 +35,7 @@ public class CustomDataMapPointGenerator extends AbstractPointGenerator {
         for (String key : customKeys) {
             Point point = buildPoint(measurementName(key), customPrefix, build)
                     .fields(customDataMap.get(key))
-                    .tag(globalTags)
+                    .tag(customDataMapTags)
                     .build();
             customPoints.add(point);
         }

--- a/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
+++ b/src/main/java/jenkinsci/plugins/influxdb/generators/JenkinsBasePointGenerator.java
@@ -67,7 +67,8 @@ public class JenkinsBasePointGenerator extends AbstractPointGenerator {
             .addField(BUILD_IS_SUCCESSFUL, ordinal < 2 ? true : false)
             .addField(PROJECT_BUILD_HEALTH, build.getParent().getBuildHealth().getScore())
             .addField(PROJECT_LAST_SUCCESSFUL, getLastSuccessfulBuild())
-            .addField(PROJECT_LAST_STABLE, getLastStableBuild());
+            .addField(PROJECT_LAST_STABLE, getLastStableBuild())
+            .tag(BUILD_RESULT, result);
 
         if(hasTestResults(build)) {
             point.addField(TESTS_FAILED, build.getAction(AbstractTestResultAction.class).getFailCount());

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -38,16 +38,21 @@ public class CustomDataMapPointGeneratorTest {
     @Test
     public void hasReportTest() {
         //check with customDataMap = null
-        CustomDataMapPointGenerator cdmGen1 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, null);
+        CustomDataMapPointGenerator cdmGen1 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
+                null, null);
         Assert.assertFalse(cdmGen1.hasReport());
 
         //check with empty customDataMap
-        CustomDataMapPointGenerator cdmGen2 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, Collections.<String, Map<String, Object>>emptyMap());
+        CustomDataMapPointGenerator cdmGen2 = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
+                Collections.<String, Map<String, Object>>emptyMap(), Collections.<String, String>emptyMap());
         Assert.assertFalse(cdmGen2.hasReport());
     }
 
     @Test
     public void generateTest() {
+
+        Map<String, String> globalTags = new HashMap<>();
+        globalTags.put("test1Tag", "testValue");
 
         Map<String, Object> customData1 = new HashMap<String, Object>();
         customData1.put("test1", 11);
@@ -66,7 +71,8 @@ public class CustomDataMapPointGeneratorTest {
 
         List<Point> pointsToWrite = new ArrayList<Point>();
 
-        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build, customDataMap);
+        CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
+                customDataMap, globalTags);
         pointsToWrite.addAll(Arrays.asList(cdmGen.generate()));
 
         String lineProtocol1;
@@ -78,7 +84,8 @@ public class CustomDataMapPointGeneratorTest {
             lineProtocol1 = pointsToWrite.get(1).lineProtocol();
             lineProtocol2 = pointsToWrite.get(0).lineProtocol();
         }
-        Assert.assertTrue(lineProtocol1.startsWith("series1,prefix=test_prefix,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test1=11i,test2=22i"));
-        Assert.assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master build_number=11i,project_name=\"test_prefix_master\",test3=33i,test4=44i"));
+
+        Assert.assertTrue(lineProtocol1.startsWith("series1,prefix=test_prefix,project_name=test_prefix_master,test1Tag=testValue build_number=11i,project_name=\"test_prefix_master\",test1=11i,test2=22i"));
+        Assert.assertTrue(lineProtocol2.startsWith("series2,prefix=test_prefix,project_name=test_prefix_master,test1Tag=testValue build_number=11i,project_name=\"test_prefix_master\",test3=33i,test4=44i"));
     }
 }

--- a/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
+++ b/src/test/java/jenkinsci/plugins/influxdb/generators/CustomDataMapPointGeneratorTest.java
@@ -51,8 +51,8 @@ public class CustomDataMapPointGeneratorTest {
     @Test
     public void generateTest() {
 
-        Map<String, String> globalTags = new HashMap<>();
-        globalTags.put("test1Tag", "testValue");
+        Map<String, String> customDataMapTags = new HashMap<>();
+        customDataMapTags.put("test1Tag", "testValue");
 
         Map<String, Object> customData1 = new HashMap<String, Object>();
         customData1.put("test1", 11);
@@ -72,7 +72,7 @@ public class CustomDataMapPointGeneratorTest {
         List<Point> pointsToWrite = new ArrayList<Point>();
 
         CustomDataMapPointGenerator cdmGen = new CustomDataMapPointGenerator(measurementRenderer, CUSTOM_PREFIX, build,
-                customDataMap, globalTags);
+                customDataMap, customDataMapTags);
         pointsToWrite.addAll(Arrays.asList(cdmGen.generate()));
 
         String lineProtocol1;


### PR DESCRIPTION
This PR adds a property to the publisher that allows for custom tags to be added with any measurement sent with CustomDataMap. This will allow for more flexibility while querying with GROUP BY.